### PR TITLE
TimeDurationPickerPreference customization

### DIFF
--- a/time-duration-picker/src/main/java/mobi/upod/timedurationpicker/TimeDurationPickerPreference.java
+++ b/time-duration-picker/src/main/java/mobi/upod/timedurationpicker/TimeDurationPickerPreference.java
@@ -98,7 +98,7 @@ public class TimeDurationPickerPreference extends DialogPreference {
         return picker;
     }
 
-    private TimeDurationPicker initPicker(TimeDurationPicker timePicker) {
+    protected TimeDurationPicker initPicker(TimeDurationPicker timePicker) {
         return timePicker;
     }
 


### PR DESCRIPTION
Change the visibility of `TimeDurationPickerPreference`'s method `initPicker()` from private to protected to allow subclasses to perform customization of the picker instance variable.

While this does not solve #8 directly, it makes the creation of a custom preference very easy, e.g:

    public class MyTimePreference extends TimeDurationPickerPreference {

      public MyTimePreference(Context context)
      {
        super(context);
      }

      public MyTimePreference(Context context, AttributeSet attrs)
      {
        super(context, attrs);
      }

      protected TimeDurationPicker initPicker(TimeDurationPicker timePicker) {
        timePicker.setTimeUnits(TimeDurationPicker.MM_SS);
        return timePicker;
      }

    }